### PR TITLE
Change `#idempotent_transaction` to return block result as is.

### DIFF
--- a/lib/idempotent_transaction.rb
+++ b/lib/idempotent_transaction.rb
@@ -25,16 +25,16 @@ module IdempotentTransaction
 
   def idempotent_transaction(force: false)
     self.class.transaction do
-      yield
+      yield.tap do
+        begin
+          save!
+        rescue ActiveRecord::RecordNotUnique
+          raise ActiveRecord::Rollback unless force
+        end
 
-      begin
-        save!
-      rescue ActiveRecord::RecordNotUnique
-        raise ActiveRecord::Rollback unless force
+        @finished = true
+        @executed = true
       end
-
-      @finished = true
-      @executed = true
     end
   end
 

--- a/spec/idempotent_transaction_spec.rb
+++ b/spec/idempotent_transaction_spec.rb
@@ -110,4 +110,12 @@ RSpec.describe IdempotentTransaction do
     expect(exec_2.finished?).to eq true
     expect(exec_2.executed?).to eq true
   end
+
+  it 'returns block result as is' do
+    exec_1 = IdempotentExecutor.new(user_id: 1, transaction_type: :post_create, signature: 'abcdefg')
+
+    block = proc { 'Block result' }
+
+    expect(exec_1.idempotent_transaction(&block)).to eq('Block result')
+  end
 end


### PR DESCRIPTION
`#idempotent_transaction` が渡されたブロックの戻り値をそのまま返すように変更しました。